### PR TITLE
perf(canvas): resize canvas to reduce lag

### DIFF
--- a/assets/doraemon-canvas/main.js
+++ b/assets/doraemon-canvas/main.js
@@ -58,10 +58,10 @@ function updateColor() {
 /*        Variables declaration        */
 /***************************************/
 
+const canvasApp = document.querySelector("#canvas-app");
 /** @type {DoraemonCanvas} doraemon */
-const doraemon = new DoraemonCanvas();
+const doraemon = new DoraemonCanvas(canvasApp, true);
 doraemon.div.id = "canvas-app";
-document.querySelector("#canvas-app").replaceWith(doraemon.div);
 
 /******************************/
 /*        canvas tools        */

--- a/assets/drawing-canvas/modules/UndoStack.js
+++ b/assets/drawing-canvas/modules/UndoStack.js
@@ -29,11 +29,17 @@ export default class UndoStack {
     this.#idx = this.#undoStack.length - 1;
   }
 
-  /** @returns {(ImageData|null)} the next state or null*/
+  /** @returns {(ImageData|null)} the next state or null */
   redo() {
     if (this.#idx == null) return null;
     if (this.#idx + 1 >= this.#undoStack.length) return null;
     return this.#undoStack[++this.#idx];
+  }
+
+  /** @returns {(ImageData|null)} the current state or null */
+  getCurrentData() {
+    if (this.#idx == null) return null;
+    return this.#undoStack[this.#idx];
   }
 
   /************************************************************/


### PR DESCRIPTION
Resize canvas so that no need to adjust MouseEvent coordinates by
multiplying a coefficient to map to canvas coordinates.

Constructor of DoraemonCanvas now accepts a parent element and a
replaceFlag.